### PR TITLE
Upgrade to SpeziViews 0.5.0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ SpeziMockWebService contributors
 ====================
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
+* [Andreas Bauer](https://github.com/Supereg)

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.7.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", .upToNextMinor(from: "0.4.0"))
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews", .upToNextMinor(from: "0.5.0"))
     ],
     targets: [
         .target(

--- a/Sources/SpeziMockWebService/RequestHeader.swift
+++ b/Sources/SpeziMockWebService/RequestHeader.swift
@@ -27,7 +27,8 @@ struct RequestHeader: View {
                         .accessibilityHidden(true)
                 }
                 Text(verbatim: "/\(request.path)/")
-                    .accessibilityLabel("Path: \(request.path)")
+                    .accessibilityLabel("Request: /\(request.path)/")
+                    .accessibilityAddTraits(.isHeader)
             }
                 .font(.title3)
                 .bold()

--- a/Sources/SpeziMockWebService/RequestHeader.swift
+++ b/Sources/SpeziMockWebService/RequestHeader.swift
@@ -20,16 +20,19 @@ struct RequestHeader: View {
                 case .add:
                     Image(systemName: "arrow.up.doc.fill")
                         .foregroundColor(.green)
+                        .accessibilityHidden(true)
                 case .delete:
                     Image(systemName: "trash.fill")
                         .foregroundColor(.red)
+                        .accessibilityHidden(true)
                 }
-                Text("/\(request.path)/")
+                Text(verbatim: "/\(request.path)/")
+                    .accessibilityLabel("Path: \(request.path)")
             }
                 .font(.title3)
                 .bold()
                 .padding(.bottom, 12)
-            Text("On \(format(request.date))")
+            Text("ON_DATE \(format(request.date))", bundle: .module)
                 .font(.subheadline)
         }
     }

--- a/Sources/SpeziMockWebService/RequestList.swift
+++ b/Sources/SpeziMockWebService/RequestList.swift
@@ -56,6 +56,7 @@ public struct RequestList: View {
                 VStack(spacing: 32) {
                     Image(systemName: "server.rack")
                         .font(.system(size: 100))
+                        .accessibilityHidden(true)
                     Text(String(localized: "MOCK_REQUESTS_LIST_PLACEHOLDER", bundle: .module))
                         .multilineTextAlignment(.center)
                 }

--- a/Sources/SpeziMockWebService/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpeziMockWebService/Resources/en.lproj/Localizable.strings
@@ -12,3 +12,5 @@
 "MOCK_REQUEST_DETAIL_HEADER" = "Request Header";
 "MOCK_REQUEST_DETAIL_BODY" = "Request Body";
 "MOCK_REQUEST_DETAIL_TITLE" = "Request";
+
+"ON_DATE %@" = "On %@";

--- a/Tests/UITests/TestAppUITests/FHIRMockWebServiceTests.swift
+++ b/Tests/UITests/TestAppUITests/FHIRMockWebServiceTests.swift
@@ -21,7 +21,7 @@ final class FHIRMockWebServiceTests: XCTestCase {
         XCTAssert(app.images["Previous Page"].waitForExistence(timeout: 2))
         app.images["Previous Page"].tap()
         
-        XCTAssert(app.staticTexts["/Test/"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Request: /Test/"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["{\"test\": \"test\"}"].waitForExistence(timeout: 2))
         
         app.navigationBars.buttons["Mock Requests"].tap()
@@ -29,6 +29,6 @@ final class FHIRMockWebServiceTests: XCTestCase {
         XCTAssert(app.images["Trash"].waitForExistence(timeout: 2))
         app.images["Trash"].tap()
         
-        XCTAssert(app.staticTexts["/TestRemoval/"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Request: /TestRemoval/"].waitForExistence(timeout: 2))
     }
 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Upgrade to SpeziViews 0.5.0

## :recycle: Current situation & Problem
SpeziViews introduced a breaking change in `0.5.0`. SpeziMockWebService updates to the latest version without any code changes.


## :gear: Release Notes 
* Compatibility with SpeziViews `0.5.0`.


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
